### PR TITLE
Add support for ssh-based Github repositories.

### DIFF
--- a/bash/openGitHubProject.sh
+++ b/bash/openGitHubProject.sh
@@ -1,5 +1,5 @@
 # This script is designed to be included in your ~/.bashrc or equivalent file loaded on bash startup.
-# Retrieves the URL for the GitHub page of a project cloned from GitHub and xdg-opens it in the default browser.
+# Retrieves the URL for the GitHub page of a project cloned from GitHub and opens it in the default browser.
 alias github=GitHub
 function GitHub()
 {

--- a/bash/openGitHubProject.sh
+++ b/bash/openGitHubProject.sh
@@ -1,5 +1,5 @@
 # This script is designed to be included in your ~/.bashrc or equivalent file loaded on bash startup.
-# Retrieves the URL for the GitHub page of a project cloned from GitHub and opens it in the default browser.
+# Retrieves the URL for the GitHub page of a project cloned from GitHub and xdg-opens it in the default browser.
 alias github=GitHub
 function GitHub()
 {
@@ -7,9 +7,15 @@ function GitHub()
         then echo "ERROR: This isnt a git directory" && return false; 
     fi
     git_url=`git config --get remote.origin.url`
-    if [[ $git_url != https://github* ]] ;
-        then echo "ERROR: Remote origin is invalid" && return false;
+
+    if [[ "${git_url}" == git@github* ]]; then
+	    repo_owner=`echo "${git_url}" | sed -Ene 's#git@github.com:([^/]*)/(.*).git#\1#p'`
+	    repo_name=`echo "${git_url}" | sed -Ene 's#git@github.com:([^/]*)/(.*).git#\2#p'`
+	    url="https://github.com/${repo_owner}/${repo_name}.git"
+    elif [[ "${git_url}" == https://github* ]]; then
+	    url=${git_url%.git}
+    else
+	    echo "ERROR: Remote origin is invalid" && return false;
     fi
-    url=${git_url%.git}
     open $url
 }

--- a/bash/openGitHubProject.sh
+++ b/bash/openGitHubProject.sh
@@ -17,5 +17,9 @@ function GitHub()
     else
 	    echo "ERROR: Remote origin is invalid" && return false;
     fi
-    open $url
+    if [[ uname == 'Linux' ]]; then 
+    	xdg-open "${url}"
+	elif [[ uname == 'Darwin' ]]; then
+		open "${url}"
+    fi
 }

--- a/bash/openGitHubProject.sh
+++ b/bash/openGitHubProject.sh
@@ -17,9 +17,10 @@ function GitHub()
     else
 	    echo "ERROR: Remote origin is invalid" && return false;
     fi
+    
     if [[ uname == 'Linux' ]]; then 
     	xdg-open "${url}"
-	elif [[ uname == 'Darwin' ]]; then
+    elif [[ uname == 'Darwin' ]]; then
 		open "${url}"
     fi
 }


### PR DESCRIPTION
Hi, 

I noticed that the previous script only supported https-based github repository. This patch adds the same functionality for ssh repos. 
It is transparent for the user. This means they don't need to know if their repository is https or ssh-based, as the script verifies both cases. Otherwise, the same error message is displayed.

Cheers

PS: This PR closes #2 .